### PR TITLE
M118 encode password

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,6 +194,13 @@ dependencies {
 
         // Moses MT connector
         implementation 'org.apache.xmlrpc:xmlrpc-client:3.1.3'
+        
+        // OSHI for native hardware info retrieval
+        implementation 'com.github.oshi:oshi-core-java11:5.6.0'     // newer version implies incompatibilities with OmegaT's version of JNA
+
+        // Suppress OSHI's internal SLF4J debug logging for clean CLI output
+        //implementation 'org.slf4j:slf4j-nop:2.0.12'
+        
     }
 
     // Test dependencies

--- a/src/org/omegat/core/team2/TeamSettings.java
+++ b/src/org/omegat/core/team2/TeamSettings.java
@@ -29,10 +29,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.Properties;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
+
+import org.omegat.core.team2.impl.TeamUtils;
 import org.omegat.util.StaticUtils;
+import org.omegat.util.Log;
 
 /**
  * Class for read/save repository-specific settings in the ~/.omegat/ directory.
@@ -51,6 +55,39 @@ public final class TeamSettings {
             configFile = new File(StaticUtils.getConfigDir(), "repositories.properties");
         }
         return configFile;
+    }
+    
+    // Should be called at first load of the class
+    static {
+        synchronized (TeamSettings.class) {
+            // Try to encrypt all passwords
+            try {
+                Properties props = new Properties(); File fOri = getConfigFile();
+                if (fOri.exists()) {
+                    try (FileInputStream in = new FileInputStream(fOri)) {
+                        props.load(in);
+                    }
+                    int change = 0;
+                    for(Map.Entry<Object, Object> e : props.entrySet()) 
+                        if (e.getKey().toString().endsWith("!password"))
+                            if (! e.getValue().toString().startsWith("***")) {
+                                props.put(e.getKey().toString(), TeamUtils.encodePassword(e.getValue().toString()));
+                                change++;
+                            }
+                    if (change > 0) {
+                        File fNew = new File(getConfigFile().getAbsolutePath() + ".new");
+                        try (FileOutputStream out = new FileOutputStream(fNew)) {            
+                            props.store(out, null);
+                        }
+                        fOri.delete(); FileUtils.moveFile(fNew, fOri);
+                        Log.log("TeamSettings: " + change + " passwords reencrypted");
+                    }
+                    else Log.log("TeamSettings: no password requires re-encryption");
+                }
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        }
     }
 
     public static synchronized Set<Object> listKeys() {

--- a/src/org/omegat/core/team2/TeamSettings.java
+++ b/src/org/omegat/core/team2/TeamSettings.java
@@ -71,7 +71,7 @@ public final class TeamSettings {
                     for(Map.Entry<Object, Object> e : props.entrySet()) 
                         if (e.getKey().toString().endsWith("!password"))
                             if (! e.getValue().toString().startsWith("***")) {
-                                props.put(e.getKey().toString(), TeamUtils.encodePassword(e.getValue().toString()));
+                                props.put(e.getKey().toString(), TeamUtils.encodePassword(TeamUtils.decodePassword(e.getValue().toString())));
                                 change++;
                             }
                     if (change > 0) {

--- a/src/org/omegat/core/team2/TeamSettings.java
+++ b/src/org/omegat/core/team2/TeamSettings.java
@@ -39,7 +39,9 @@ import org.omegat.util.StaticUtils;
 import org.omegat.util.Log;
 
 /**
- * Class for read/save repository-specific settings in the ~/.omegat/ directory.
+ * Class for read/save repository-specific settings in the ~/.omegat/ directory. <br/>
+ * Warning: this class manages calls to encryption methods from TeamUtils, deciding when it is necessary <br/>
+ * Do not encode/decode values before calling TeamSettings.get nor TeamSettings.set!!!
  *
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
@@ -57,6 +59,14 @@ public final class TeamSettings {
         return configFile;
     }
     
+    /** 
+     * Whenever the value should be stored as encrypted or not
+     * Private, because that should remain transparent to users
+     **/
+    private static boolean needsEncryption(String key) {
+        return key.endsWith("!password");
+    }
+    
     // Should be called at first load of the class
     static {
         synchronized (TeamSettings.class) {
@@ -69,7 +79,7 @@ public final class TeamSettings {
                     }
                     int change = 0;
                     for(Map.Entry<Object, Object> e : props.entrySet()) 
-                        if (e.getKey().toString().endsWith("!password"))
+                        if (needsEncryption(e.getKey().toString()))
                             if (! e.getValue().toString().startsWith("***")) {
                                 props.put(e.getKey().toString(), TeamUtils.encodePassword(TeamUtils.decodePassword(e.getValue().toString())));
                                 change++;
@@ -108,7 +118,7 @@ public final class TeamSettings {
     }
 
     /**
-     * Get setting.
+     * Get setting directly readable by caller - decrypted if necessary
      */
     public static synchronized String get(String key) {
         try {
@@ -121,14 +131,15 @@ public final class TeamSettings {
                     in.close();
                 }
             }
-            return p.getProperty(key);
+            if (needsEncryption(key)) return TeamUtils.decodePassword(p.getProperty(key));
+            else return p.getProperty(key);
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
     }
 
     /**
-     * Update setting.
+     * Update setting. Encrypts it if necessary  - do not use set(key, encode(value))!!!
      */
     public static synchronized void set(String key, String newValue) {
         try {
@@ -146,6 +157,7 @@ public final class TeamSettings {
                 f.getParentFile().mkdirs();
             }
             if (newValue != null) {
+                if (needsEncryption(key)) newValue = TeamUtils.encodePassword(newValue);
                 p.setProperty(key, newValue);
             } else {
                 p.remove(key);

--- a/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -137,7 +137,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
         String url = uri.toString();
         Credentials credentials = new Credentials();
         credentials.username = TeamSettings.get(url + "!" + KEY_USERNAME_SUFFIX);
-        credentials.password = TeamUtils.decodePassword(TeamSettings.get(url + "!" + KEY_PASSWORD_SUFFIX));
+        credentials.password = TeamSettings.get(url + "!" + KEY_PASSWORD_SUFFIX);
         return credentials;
     }
 
@@ -145,7 +145,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
         String url = uri.toString();
         try {
             TeamSettings.set(url + "!" + KEY_USERNAME_SUFFIX, credentials.username);
-            TeamSettings.set(url + "!" + KEY_PASSWORD_SUFFIX, TeamUtils.encodePassword(credentials.password));
+            TeamSettings.set(url + "!" + KEY_PASSWORD_SUFFIX, credentials.password);
         } catch (Exception e) {
             Core.getMainWindow().displayErrorRB(e, "TEAM_ERROR_SAVE_CREDENTIALS", null, "TF_ERROR");
         }

--- a/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -133,7 +133,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
         predefined.put("fingerprint." + url, predefinedFingerprint);
     }
 
-    private Credentials loadCredentials(URIish uri) {
+    private Credentials loadCredentials(URIish uri) throws Exception {
         String url = uri.toString();
         Credentials credentials = new Credentials();
         credentials.username = TeamSettings.get(url + "!" + KEY_USERNAME_SUFFIX);
@@ -175,8 +175,14 @@ public class GITCredentialsProvider extends CredentialsProvider {
         String predefinedFingerprint = predefined.get("fingerprint." + url);
 
         // get saved
-        Credentials credentials = loadCredentials(uri);
-
+        Credentials credentials;
+        try {
+            credentials = loadCredentials(uri);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            throw new UnsupportedCredentialItem(uri, "Cannot decrypt password");
+        }
+    
         boolean ok = false;
         // theoretically, username can be unknown, but in practice it is always set, so not requested.
         for (CredentialItem i : items) {
@@ -356,10 +362,14 @@ public class GITCredentialsProvider extends CredentialsProvider {
             throw new KnownException("TEAM_PREDEFINED_CREDENTIALS_ERROR");
         }
 
-        Credentials credentials = loadCredentials(uri);
-        credentials.username = null;
-        credentials.password = null;
-        saveCredentials(uri, credentials);
+        try {
+            Credentials credentials = loadCredentials(uri);
+            credentials.username = null;
+            credentials.password = null;
+            saveCredentials(uri, credentials);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
     }
 
     private static String extractFingerprint(String text) {

--- a/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
+++ b/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
@@ -104,7 +104,7 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
         return READ_TIMEOUT;
     }
 
-    protected SVNAuthentication ask(String kind, SVNURL url, String message) throws SVNException {
+    protected SVNAuthentication ask(String kind, SVNURL url, String message) throws Exception {
         if (ISVNAuthenticationManager.PASSWORD.equals(kind)) {
             // ask username+password
         } else if (ISVNAuthenticationManager.SSH.equals(kind)) {
@@ -161,8 +161,12 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
                 Log.logDebug(LOGGER, "ssh-agent support couldn't be initialized: {0}", e.getMessage());
             }
         }
-        String user = TeamSettings.get(repoUrl + "!" + KEY_USERNAME_SUFFIX);
-        String pass = TeamUtils.decodePassword(TeamSettings.get(repoUrl + "!" + KEY_PASSWORD_SUFFIX));
+        String user = TeamSettings.get(repoUrl + "!" + KEY_USERNAME_SUFFIX); String pass;
+        try {
+            pass = TeamUtils.decodePassword(TeamSettings.get(repoUrl + "!" + KEY_PASSWORD_SUFFIX));
+        } catch (Exception ex) {
+            throw new KnownException("TEAM_PREDEFINED_CREDENTIALS_ERROR");
+        }
         if (user != null && pass != null) {
             if (ISVNAuthenticationManager.PASSWORD.equals(kind)) {
                 return SVNPasswordAuthentication.newInstance(user, pass.toCharArray(), false, url, false);
@@ -172,14 +176,22 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
                 throw new SVNException(SVNErrorMessage.create(SVNErrorCode.AUTHN_NO_PROVIDER));
             }
         }
-        return ask(kind, url, OStrings.getString("TEAM_USERPASS_FIRST", url.getPath()));
+        try {
+            return ask(kind, url, OStrings.getString("TEAM_USERPASS_FIRST", url.getPath()));
+        } catch (Exception ex) {
+            throw new KnownException("TEAM_PREDEFINED_CREDENTIALS_ERROR");
+        }
     }
 
     public SVNAuthentication getNextAuthentication(String kind, String realm, SVNURL url) throws SVNException {
         if (predefinedUser != null && predefinedPass != null) {
             throw new KnownException("TEAM_PREDEFINED_CREDENTIALS_ERROR");
         }
-        return ask(kind, url, OStrings.getString("TEAM_USERPASS_WRONG", url.getPath()));
+        try {
+            return ask(kind, url, OStrings.getString("TEAM_USERPASS_WRONG", url.getPath()));
+        } catch (Exception ex) {
+            throw new KnownException("TEAM_PREDEFINED_CREDENTIALS_ERROR");
+        }
     };
 
     @Override

--- a/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
+++ b/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
@@ -128,7 +128,7 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
         String user = userPassDialog.userText.getText();
         String pass = new String(userPassDialog.passwordField.getPassword());
         TeamSettings.set(repoUrl + "!" + KEY_USERNAME_SUFFIX, user);
-        TeamSettings.set(repoUrl + "!" + KEY_PASSWORD_SUFFIX, TeamUtils.encodePassword(pass));
+        TeamSettings.set(repoUrl + "!" + KEY_PASSWORD_SUFFIX, pass);    // encryption to be managed by TeamSettings!!!
 
         if (ISVNAuthenticationManager.PASSWORD.equals(kind)) {
             return SVNPasswordAuthentication.newInstance(user, pass.toCharArray(), false, url, false);
@@ -163,7 +163,7 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
         }
         String user = TeamSettings.get(repoUrl + "!" + KEY_USERNAME_SUFFIX); String pass;
         try {
-            pass = TeamUtils.decodePassword(TeamSettings.get(repoUrl + "!" + KEY_PASSWORD_SUFFIX));
+            pass = TeamSettings.get(repoUrl + "!" + KEY_PASSWORD_SUFFIX);   // always returns clear value, even if encrypted!
         } catch (Exception ex) {
             throw new KnownException("TEAM_PREDEFINED_CREDENTIALS_ERROR");
         }

--- a/src/org/omegat/core/team2/impl/TeamUtils.java
+++ b/src/org/omegat/core/team2/impl/TeamUtils.java
@@ -25,31 +25,166 @@
 
 package org.omegat.core.team2.impl;
 
+import oshi.SystemInfo;
+import oshi.hardware.ComputerSystem;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.software.os.OperatingSystem;
+
+import java.security.NoSuchAlgorithmException;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.BadPaddingException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.spec.InvalidKeySpecException;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.io.File;
+import java.io.FileReader;
+import java.io.BufferedReader;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.security.spec.KeySpec;
+import javax.crypto.*;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
 
 /**
  * Some utility methods for team code.
  *
  * @author Alex Buloichik (alex73mail@gmail.com)
+ * @author Thomas CORDONNIER, Kos Ivantsov
  */
 public final class TeamUtils {
 
     private TeamUtils() {
     }
+    
+    // Helper to check if a string successfully retrieved a value and is not an OSHI "unknown" placeholder
+    private static boolean isValid(String s) {
+        return s != null && !s.trim().isEmpty() && !s.equalsIgnoreCase("unknown");
+    }
+    
+    /** Hardware-dependent key, based on Kos's algorithm **/
+    public static byte[] oshiKey() throws NoSuchAlgorithmException, UnsupportedEncodingException {
+        SystemInfo systemInfo = new SystemInfo();
+        OperatingSystem os = systemInfo.getOperatingSystem();
+        HardwareAbstractionLayer hal = systemInfo.getHardware();
+        ComputerSystem computerSystem = hal.getComputerSystem();
+        CentralProcessor processor = hal.getProcessor();
+        
 
-    public static String encodePassword(String pass) {
-        if (pass == null) {
-            return null;
+        // Gather raw data
+        String osFamily = os.getFamily();
+        String hardwareUUID = computerSystem.getHardwareUUID();
+        String baseboardSerial = computerSystem.getBaseboard().getSerialNumber();
+        String processorId = processor.getProcessorIdentifier().getProcessorID();
+        String userName = System.getProperty("user.name");
+
+        // Fetch Linux Software ID for the output display
+        String linuxSoftwareId = "N/A";
+        if (osFamily.toLowerCase().contains("linux") || osFamily.toLowerCase().contains("debian") || osFamily.toLowerCase().contains("ubuntu")) {
+            String[] paths = {"/etc/machine-id", "/var/lib/dbus/machine-id"};
+            for (String path : paths) {
+                File file = new File(path);
+                if (file.exists() && file.canRead()) {
+                    try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+                        String id = reader.readLine();
+                        if (isValid(id)) {
+                            linuxSoftwareId = id.trim();
+                            break;
+                        }
+                    } catch (Exception ignored) {}
+                }
+            }
         }
-        return Base64.getEncoder().encodeToString(pass.getBytes(StandardCharsets.UTF_8));
+
+        // Determine the best available identifier
+        String primaryId = null;
+
+        if (isValid(hardwareUUID)) {
+            primaryId = hardwareUUID;
+        } else if (isValid(baseboardSerial)) {
+            primaryId = baseboardSerial;
+        } else if (!linuxSoftwareId.equals("N/A")) {
+            primaryId = linuxSoftwareId;
+        } else if (isValid(processorId)) {
+            primaryId = processorId;
+        } else {
+            primaryId = System.getProperty("os.arch") + "-" + System.getProperty("user.home");
+        }
+
+        // Generate the raw Salt String and hash it
+        String rawSalt = primaryId + "-" + userName;
+        
+        MessageDigest sha = MessageDigest.getInstance("SHA-256");
+        return sha.digest(rawSalt.getBytes("UTF-8"));            
+    }
+    
+    private static final String OT_PRIVATE_KEY = "sodpfizeriu";  // random-generated, do not change
+    
+    // Source: https://howtodoinjava.com/java/java-security/aes-256-encryption-decryption/
+    private static final int KEY_LENGTH = 256;
+    private static final int ITERATION_COUNT = 65536;
+
+    public static String encodePassword(String pass) throws NoSuchAlgorithmException, UnsupportedEncodingException, BadPaddingException,
+        InvalidKeyException, IllegalBlockSizeException, InvalidKeySpecException, NoSuchPaddingException, InvalidAlgorithmParameterException {
+        
+        if (pass == null) return null;
+        //return Base64.getEncoder().encodeToString(pass.getBytes("UTF-8"));
+        
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] iv = new byte[16];
+        secureRandom.nextBytes(iv);
+        IvParameterSpec ivspec = new IvParameterSpec(iv);
+
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+        KeySpec spec = new PBEKeySpec(OT_PRIVATE_KEY.toCharArray(), oshiKey(), ITERATION_COUNT, KEY_LENGTH);
+        SecretKey tmp = factory.generateSecret(spec);
+        SecretKeySpec secretKeySpec = new SecretKeySpec(tmp.getEncoded(), "AES");
+
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, ivspec);
+
+        byte[] cipherText = cipher.doFinal(pass.getBytes("UTF-8"));
+        byte[] encryptedData = new byte[iv.length + cipherText.length];
+        System.arraycopy(iv, 0, encryptedData, 0, iv.length);
+        System.arraycopy(cipherText, 0, encryptedData, iv.length, cipherText.length);
+        // *** to indicate that we use AES (without, it is supposed to be simple Base64 encryption as in older releases of OmegaT)
+        return "***" + Base64.getEncoder().encodeToString(encryptedData);   
     }
 
-    public static String decodePassword(String pass) {
-        if (pass == null) {
-            return null;
+    public static String decodePassword(String pass) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeySpecException, 
+        IllegalBlockSizeException, InvalidKeyException, BadPaddingException, NoSuchPaddingException, InvalidAlgorithmParameterException {
+        
+        if (pass == null) return null;
+        if (pass.startsWith("***")) {
+            byte[] encryptedData = Base64.getDecoder().decode(pass = pass.substring(3));
+            byte[] iv = new byte[16];
+            System.arraycopy(encryptedData, 0, iv, 0, iv.length);
+            IvParameterSpec ivspec = new IvParameterSpec(iv);
+
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            KeySpec spec = new PBEKeySpec(OT_PRIVATE_KEY.toCharArray(), oshiKey(), ITERATION_COUNT, KEY_LENGTH);
+            SecretKey tmp = factory.generateSecret(spec);
+            SecretKeySpec secretKeySpec = new SecretKeySpec(tmp.getEncoded(), "AES");
+
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivspec);
+
+            byte[] cipherText = new byte[encryptedData.length - 16];
+            System.arraycopy(encryptedData, 16, cipherText, 0, cipherText.length);
+
+            byte[] decryptedText = cipher.doFinal(cipherText);
+            return new String(decryptedText, "UTF-8");            
+        } else {    // compatibility with other versions of OmegaT      */  
+            byte[] data = Base64.getDecoder().decode(pass);
+            return new String(data, StandardCharsets.UTF_8);
         }
-        byte[] data = Base64.getDecoder().decode(pass);
-        return new String(data, StandardCharsets.UTF_8);
     }
 }

--- a/test/src/org/omegat/core/team2/EncryptionTest.java
+++ b/test/src/org/omegat/core/team2/EncryptionTest.java
@@ -36,7 +36,7 @@ public class EncryptionTest {
     public void testEncodeDecode() throws Exception {
         String test = "this is a test";
         test = TeamUtils.encodePassword(test);
-        System.out.println("Encrypted: " + test);
+        assertEquals(test.substring(0, 3), "***");
         test = TeamUtils.decodePassword(test);
         assertEquals(test, "this is a test");
     }
@@ -44,7 +44,7 @@ public class EncryptionTest {
     @Test
 	public void testRetroCompatible() throws Exception {
         // Pure Base 64, without AES 
-        String test = "dGhpcyBpcyBhIHRlc3QK";
+        String test = "dGhpcyBpcyBhIHRlc3Q=";
         assertEquals(TeamUtils.decodePassword(test), "this is a test");        
 	}
 	

--- a/test/src/org/omegat/core/team2/EncryptionTest.java
+++ b/test/src/org/omegat/core/team2/EncryptionTest.java
@@ -1,0 +1,51 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+ with fuzzy matching, translation memory, keyword search,
+ glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Thomas CORDONNIER
+ Home page: http://www.omegat.org/
+ Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.team2;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+import org.omegat.core.team2.impl.TeamUtils;
+
+public class EncryptionTest {
+
+    @Test
+    public void testEncodeDecode() throws Exception {
+        String test = "this is a test";
+        test = TeamUtils.encodePassword(test);
+        System.out.println("Encrypted: " + test);
+        test = TeamUtils.decodePassword(test);
+        assertEquals(test, "this is a test");
+    }
+    
+    @Test
+	public void testRetroCompatible() throws Exception {
+        // Pure Base 64, without AES 
+        String test = "dGhpcyBpcyBhIHRlc3QK";
+        assertEquals(TeamUtils.decodePassword(test), "this is a test");        
+	}
+	
+}


### PR DESCRIPTION
Have passwords in repositories.properties encrypted using a key based on the computer
The file remains a properties file, only passwords (neither user names nor property keys) are encrypted

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

http://captsan.mantis.silvestris-lab.org/view.php?id=118

